### PR TITLE
Configure Annoation Based Resource Tracking as the default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.8.6
+version: 0.8.7

--- a/templates/plumbing/argocd.yaml
+++ b/templates/plumbing/argocd.yaml
@@ -36,7 +36,7 @@ spec:
       hs.status = "Progressing"
       hs.message = "Waiting for PVC"
       return hs
-
+  resourceTrackingMethod: {{ $.Values.clusterGroup.argoCD.resourceTrackingMethod}}
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   applicationSet:
     resources:

--- a/values.schema.json
+++ b/values.schema.json
@@ -548,6 +548,15 @@
         "initContainers": {
           "type": "array",
           "description": "A list of initContainers to add to the repo-server if needed"
+        },
+        "resourceTrackingMethod": {
+          "type": "string",
+          "description": "ResourceTrackingMethod defines how Argo CD should track resources that it manages",
+          "enum": [
+            "annotation",
+            "label",
+            "annotation+label"
+          ]
         }
       }
     },

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,8 @@ clusterGroup:
   argoCD:
     initContainers: []
     configManagementPlugins: []
+    # resource tracking can be set to annotation, label, or annotation+label
+    resourceTrackingMethod: annotation
 
   imperative:
     jobs: []


### PR DESCRIPTION
This PR enables the ability to configure the resource tracking method and sets the default option to `annotation`.

https://argo-cd.readthedocs.io/en/stable/user-guide/resource_tracking/

Out of the box, if un-configured, the default option is `label` which has several issues.

The RH implementation of Serverless is a good example of a resource that does not play nicely with the label based tracking.  Serverless will over-eagerly apply the labels to child objects such as Routes that it creates, which Argo then interprets as an object that it should be managing, but since the Route doesn't exist in the git repo it thinks the object should be pruned.

The label Argo uses is also likely to have a conflict with a label a user may wish to manually set on objects.

Why should annotation be the default?

There is very little downside to annotation based tracking.  Overall it is more reliable and something that the upstream ArgoCD community plans to migrate to as the default in the future.