### PR TITLE
Make resourcehealthchecks configurable

### DIFF
--- a/templates/plumbing/argocd.yaml
+++ b/templates/plumbing/argocd.yaml
@@ -16,27 +16,10 @@ metadata:
 spec:
 # Adding health checks to argocd to prevent pvc resources
 # that aren't bound state from blocking deployments
+{{- if len $.Values.clusterGroup.argoCD.resourceHealthChecks }}
   resourceHealthChecks:
-  - kind: PersistentVolumeClaim
-    check: |
-      hs = {}
-      if obj.status ~= nil then
-        if obj.status.phase ~= nil then
-          if obj.status.phase == "Pending" then
-            hs.status = "Healthy"
-            hs.message = obj.status.phase
-            return hs
-          elseif obj.status.phase == "Bound" then
-            hs.status = "Healthy"
-            hs.message = obj.status.phase
-            return hs
-          end
-        end
-      end
-      hs.status = "Progressing"
-      hs.message = "Waiting for PVC"
-      return hs
-
+{{- toYaml $.Values.clusterGroup.argoCD.resourceHealthChecks | nindent 4 }}
+{{- end }}
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   applicationSet:
     resources:

--- a/values.schema.json
+++ b/values.schema.json
@@ -548,6 +548,13 @@
         "initContainers": {
           "type": "array",
           "description": "A list of initContainers to add to the repo-server if needed"
+        },
+        "resourceHealthChecks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ArgoCDResourceHealthChecks"
+          },
+          "description": "ResourceHealthChecks customizes resource health check behavior."
         }
       }
     },
@@ -580,6 +587,21 @@
         "name",
         "image"
       ]
+    },
+    "ArgoCDResourceHealthChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "check": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      }
     },
     "IndexImages": {
       "type": "object",

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,26 @@ clusterGroup:
   argoCD:
     initContainers: []
     configManagementPlugins: []
+    resourceHealthChecks:
+      - kind: PersistentVolumeClaim
+        check: |
+          hs = {}
+          if obj.status ~= nil then
+            if obj.status.phase ~= nil then
+              if obj.status.phase == "Pending" then
+                hs.status = "Healthy"
+                hs.message = obj.status.phase
+                return hs
+              elseif obj.status.phase == "Bound" then
+                hs.status = "Healthy"
+                hs.message = obj.status.phase
+                return hs
+              end
+            end
+          end
+          hs.status = "Progressing"
+          hs.message = "Waiting for PVC"
+          return hs
 
   imperative:
     jobs: []


### PR DESCRIPTION
Currently health checks are hardcoded into the helm chart and not configurable in the pattern.

This update moves the default health check for a pvc into the values file to make it a configurable option by end users so they can add additional health checks if required.