### PR TITLE
Update scheduler.yaml to prevent deletion/prune

### DIFF
--- a/templates/core/scheduler.yaml
+++ b/templates/core/scheduler.yaml
@@ -4,6 +4,8 @@ apiVersion: config.openshift.io/v1
 kind: Scheduler
 metadata:
   name: cluster
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
 spec:
 {{- toYaml .Values.clusterGroup.scheduler | nindent 2 }}
 {{- end -}}


### PR DESCRIPTION
OpenShift doesn't allow to delete the scheduler resource, therefore if a user removes a pattern, it will never succeed as argocd won't be able to delete the managed resource (which is indeed something good).

Added delete/prune annotations so it doesn't fails and prevents a successful cascade deletion of all resources when removing a pattern which configures the scheduler.

Maybe the ServerSideApply=true would also help to be less intrusive.