### PR TITLE
Changes around the default argocd policy

### DIFF
--- a/templates/plumbing/argocd.yaml
+++ b/templates/plumbing/argocd.yaml
@@ -66,7 +66,12 @@ spec:
           memory: 128Mi
   initialSSHKnownHosts: {}
   rbac:
-    defaultPolicy: role:admin
+    defaultPolicy: role:readonly
+    policy: |-
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+      g, admin, role:admin
+    scopes: '[groups, email]'
   repo:
     initContainers:
     - command:


### PR DESCRIPTION
We do two main changes:
1. We set the `defaultPolicy` to `role:readonly`. This allows any
   authenticated user to see the the argo applications
2. We add a `g, admin, role:admin` and make sure that we get the `email`
   scope from the OIDC as well. This allows the RHDP user `admin` to
   work out of the box.

Tested as follows:
1. Logged in on the clusterwide argo as kube admin and could still see all apps
   and could refresh/sync
2. Logged in as htpasswd user foo and could see the apps in read-only and could
   not sync
3. Logged in as htpasswd user admin and could see the apps and could
   sync/refresh them
