### PR TITLE
Remove duplicate resources key in argocd manifest

### DIFF
--- a/templates/plumbing/argocd.yaml
+++ b/templates/plumbing/argocd.yaml
@@ -153,13 +153,6 @@ spec:
         name: {{ $cmp.name }}
 {{- end }}
 {{- end }}
-    resources:
-      limits:
-        cpu: "1"
-        memory: 512Mi
-      requests:
-        cpu: 250m
-        memory: 256Mi
 {{- if $.Values.clusterGroup.argoCD.resourceExclusions }}
   resourceExclusions: {{- $.Values.clusterGroup.argoCD.resourceExclusions | toYaml | indent 2 }}
 {{- end }}

--- a/tests/argocd_test.yaml
+++ b/tests/argocd_test.yaml
@@ -1,0 +1,11 @@
+suite: Test argocd with default values
+templates:
+  - templates/plumbing/argocd.yaml
+release:
+  name: release-test
+tests:
+  - it: should contain argocd by default
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ArgoCD


### PR DESCRIPTION
Add basic unit test to render out argocd template, which would catch
duplicate keys in template.
