### PR TITLE
Fix the mountpath for the trusted bundles

### DIFF
--- a/templates/imperative/_helpers.tpl
+++ b/templates/imperative/_helpers.tpl
@@ -99,7 +99,7 @@
   name: trusted-ca-bundle
 - mountPath: /var/run/trusted-hub
   name: trusted-hub-bundle
-- mountPath: /tmp/ca-bundles
+- mountPath: /etc/pki/tls/certs
   name: ca-bundles
 {{- end }}
 


### PR DESCRIPTION
In the imperative framework. The `fetch-ca` initcontainer will fetch all
the needed CAs and write them to the `/tmp/ca-bundles/ca-bundle.crt`
file which is mounted to a local path called `ca-bundles`

Just like in the git-init initcontainer we need to bindmount that
`ca-bundles` volume and mount it to `/etc/pki/tls/certs` so that
all those certs are actually used by any ssl using tool running
in the imperative container.

Tested and now any ansible.builtin.uri call pointing to a local gitea
route works without the `validate_certs: false` parameter.
