### PR TITLE
Only create subscriptions if they have a name

### DIFF
--- a/templates/core/subscriptions.yaml
+++ b/templates/core/subscriptions.yaml
@@ -1,5 +1,6 @@
 {{- range .Values.clusterGroup.subscriptions }}
 {{- $subs := . }}
+{{- if $subs.name }}
 {{- $installPlanValue := .installPlanApproval }}
 
 {{- if $subs.namespaces }}
@@ -115,4 +116,5 @@ spec:
           {{- end }}
 ---
 {{- end }}{{/* if $subs.sequenceJob */}}
+{{- end }}{{/* if $subs.name */}}
 {{- end }}{{/* range .Values.clusterGroup.subscriptions */}}


### PR DESCRIPTION
Our CI pipelines use HELM_EXTRA_OPTS to override the value of pre-release subscriptions. These extra values are baked into the pattern itself and are ultimately propagated to the applications argocd maintains on our edge clusters as well. So a value like `clusterGroup.subscriptions.acm.channel` will lead to the clustergroup chart trying to deploy a subscription but without a name since `clusterGroup.subscriptions.acm.name` IS NOT set in values-group-one.yaml in the pattern's repo. Argo is then unable to create this Subscription in the edge cluster since it is a malformed Kubernetes object without a name and then nothing from the clustergroup is created in the edge cluster.