### PR TITLE
Add dependency on vp-rbac chart to support externalized RBAC

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,3 +9,7 @@ maintainers:
   - name: Validated Patterns Team
     email: validatedpatterns@googlegroups.com
 icon: https://validatedpatterns.io/images/validated-patterns.png
+dependencies:
+  - name: vp-rbac
+    version: "0.1.*"
+    repository: "https://charts.validatedpatterns.io"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.9.20
+version: 0.9.21
 home: https://github.com/validatedpatterns/clustergroup-chart
 maintainers:
   - name: Validated Patterns Team

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # clustergroup
 
-![Version: 0.9.20](https://img.shields.io/badge/Version-0.9.20-informational?style=flat-square)
+![Version: 0.9.21](https://img.shields.io/badge/Version-0.9.21-informational?style=flat-square)
 
 A Helm chart to create per-clustergroup ArgoCD applications and any required namespaces or subscriptions.
 
 This chart is used to set up the basic building blocks in [Validated Patterns](https://validatedpatterns.io)
+
+### Notable changes
+
+* v0.9.21: Include dependency on vp-rbac. This will be needed to support OLMv1 subscriptions soon.
 
 **Homepage:** <https://github.com/validatedpatterns/clustergroup-chart>
 
@@ -13,6 +17,12 @@ This chart is used to set up the basic building blocks in [Validated Patterns](h
 | Name | Email | Url |
 | ---- | ------ | --- |
 | Validated Patterns Team | <validatedpatterns@googlegroups.com> |  |
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.validatedpatterns.io | vp-rbac | 0.1.* |
 
 ## Values
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -7,6 +7,10 @@
 
 This chart is used to set up the basic building blocks in [Validated Patterns](https://validatedpatterns.io)
 
+### Notable changes
+
+* v0.9.21: Include dependency on vp-rbac. This will be needed to support OLMv1 subscriptions soon.
+
 {{ template "chart.homepageLine" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -167,4 +167,3 @@ secretStore:
 # during the installation
 #secretsBase:
 #  key: secret/data/hub
-


### PR DESCRIPTION
This is to support OLMv1, which requires the ability to create serviceAccounts to install subscriptions at the clusterGroup level.