### PR TITLE
auto truncate gitops namespace

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.9.30
+version: 0.9.31
 home: https://github.com/validatedpatterns/clustergroup-chart
 maintainers:
   - name: Validated Patterns Team

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clustergroup
 
-![Version: 0.9.30](https://img.shields.io/badge/Version-0.9.30-informational?style=flat-square)
+![Version: 0.9.31](https://img.shields.io/badge/Version-0.9.31-informational?style=flat-square)
 
 A Helm chart to create per-clustergroup ArgoCD applications and any required namespaces or subscriptions.
 
@@ -8,6 +8,7 @@ This chart is used to set up the basic building blocks in [Validated Patterns](h
 
 ### Notable changes
 
+* v0.9.31: Gitops namespace automatically truncated if too long
 * v0.9.27: Introduce support for OLMv1 Subscriptions
 * v0.9.25: One more update after fixing a relative path issue in the repository builder
 * v0.9.23: Update dependencies on helm repository builder.

--- a/templates/plumbing/applications.yaml
+++ b/templates/plumbing/applications.yaml
@@ -1,4 +1,4 @@
-{{- $namespace := print $.Values.global.pattern "-" $.Values.clusterGroup.name }}
+{{- $namespace := include "clustergroup.gitops.namespace" . }}
 {{- range .Values.clusterGroup.applications }}
 {{- if .disabled }} {{- /* This allows us to null out an Application entry by specifying disabled: true in an override file */}}
 {{- else }}
@@ -43,7 +43,7 @@ spec:
       helm:
         ignoreMissingValueFiles: true
         values: |
-          extraParametersNested: 
+          extraParametersNested:
           {{- range $k, $v := $.Values.extraParametersNested }}
             {{ $k }}: {{ printf "%s" $v | quote }}
           {{- end }}

--- a/templates/plumbing/argocd.yaml
+++ b/templates/plumbing/argocd.yaml
@@ -1,4 +1,4 @@
-{{- $namespace := print $.Values.global.pattern "-" $.Values.clusterGroup.name }}
+{{- $namespace := include "clustergroup.gitops.namespace" . }}
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:

--- a/templates/plumbing/gitops-namespace.yaml
+++ b/templates/plumbing/gitops-namespace.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: {{ $.Values.global.pattern }}-{{ .Values.clusterGroup.name }}
+    name: {{ include "clustergroup.gitops.namespace" . }}
   # The name here needs to be consistent with
   # - acm/templates/policies/application-policies.yaml
   # - clustergroup/templates/applications.yaml
   # - any references to secrets and route URLs in documentation
-  name: {{ $.Values.global.pattern }}-{{ .Values.clusterGroup.name }}
+  name: {{ include "clustergroup.gitops.namespace" . }}
 spec: {}

--- a/templates/plumbing/projects.yaml
+++ b/templates/plumbing/projects.yaml
@@ -1,12 +1,12 @@
-{{- $namespace := print $.Values.global.pattern "-" $.Values.clusterGroup.name }}
+{{- $namespace := include "clustergroup.gitops.namespace" . }}
 {{- /*
   We first check if projects are defined as a map.  If it is we call
   our helper function in _helpers.tpl to process the projects
-  described in the values file. This is to support issue 
+  described in the values file. This is to support issue
   https://github.com/validatedpatterns/common/issues/459 created by our customer.
 */ -}}
 {{- if kindIs "map" .Values.clusterGroup.projects }}
-{{- template "clustergroup.template.plumbing.projects.map" (list .Values.clusterGroup.projects $namespace $.Values.enabled) }}  
+{{- template "clustergroup.template.plumbing.projects.map" (list .Values.clusterGroup.projects $namespace $.Values.enabled) }}
 {{- else }}
 {{- range .Values.clusterGroup.projects }}
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Part of the fix for https://github.com/validatedpatterns/clustergroup-chart/issues/61.

Hold on merging until I am confident of all the places that need to be updated (ACM chart, possibly ansible playbooks as well). This should fix for the clustergroup chart though...