### PR TITLE
Restore custom inferenceservice healthcheck

### DIFF
--- a/tests/argocd_test.yaml
+++ b/tests/argocd_test.yaml
@@ -36,6 +36,76 @@ tests:
                 hs.status = "Progressing"
                 hs.message = "Waiting for PVC"
                 return hs
+            - kind: InferenceService
+              group: serving.kserve.io
+              check: |
+                local health_status = {}
+
+                health_status.status = "Progressing"
+                health_status.message = "Waiting for InferenceService to report status..."
+
+                if obj.status ~= nil then
+
+                  local progressing = false
+                  local degraded = false
+                  local status_false = 0
+                  local status_unknown = 0
+                  local msg = ""
+
+                  if obj.status.modelStatus ~= nil then
+                    if obj.status.modelStatus.transitionStatus ~= "UpToDate" then
+                      if obj.status.modelStatus.transitionStatus == "InProgress" then
+                        progressing = true
+                      else
+                        degraded = true
+                      end
+                      msg = msg .. "0: transitionStatus | " .. obj.status.modelStatus.transitionStatus
+                    end
+                  end
+
+                  if obj.status.conditions ~= nil then
+                    for i, condition in pairs(obj.status.conditions) do
+
+                      -- A condition is healthy if its status is True.
+                      -- However, for the 'Stopped' condition, a 'False' status is the healthy state.
+                      local is_healthy_condition = (condition.status == "True")
+                      if condition.type == "Stopped" then
+                        is_healthy_condition = (condition.status == "False")
+                      end
+
+                      if not is_healthy_condition then
+                        -- This condition represents a problem, so update counters and the message.
+                        if condition.status == "Unknown" then
+                          status_unknown = status_unknown + 1
+                        else
+                          status_false = status_false + 1
+                        end
+
+                        msg = msg .. " | " .. i .. ": " .. condition.type .. " | " .. condition.status
+                        if condition.reason ~= nil and condition.reason ~= "" then
+                          msg = msg .. " | " .. condition.reason
+                        end
+                        if condition.message ~= nil and condition.message ~= "" then
+                          msg = msg .. " | " .. condition.message
+                        end
+                      end
+
+                    end
+
+                    if progressing == false and degraded == false and status_unknown == 0 and status_false == 0 then
+                      health_status.status = "Healthy"
+                      msg = "InferenceService is healthy."
+                    elseif degraded == false and status_unknown >= 0 then
+                      health_status.status = "Progressing"
+                    else
+                      health_status.status = "Degraded"
+                    end
+
+                    health_status.message = msg
+                  end
+                end
+
+                return health_status
 
   - it: should render custom resourceHealthChecks correctly
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,80 @@ clusterGroup:
           hs.status = "Progressing"
           hs.message = "Waiting for PVC"
           return hs
+
+      # Drop once upstream argo cd handles the stopped field correctly
+      # As of 20251001 there is not a pr/issue in argo yet
+      - kind: InferenceService
+        group: serving.kserve.io
+        check: |
+          local health_status = {}
+
+          health_status.status = "Progressing"
+          health_status.message = "Waiting for InferenceService to report status..."
+
+          if obj.status ~= nil then
+
+            local progressing = false
+            local degraded = false
+            local status_false = 0
+            local status_unknown = 0
+            local msg = ""
+
+            if obj.status.modelStatus ~= nil then
+              if obj.status.modelStatus.transitionStatus ~= "UpToDate" then
+                if obj.status.modelStatus.transitionStatus == "InProgress" then
+                  progressing = true
+                else
+                  degraded = true
+                end
+                msg = msg .. "0: transitionStatus | " .. obj.status.modelStatus.transitionStatus
+              end
+            end
+
+            if obj.status.conditions ~= nil then
+              for i, condition in pairs(obj.status.conditions) do
+
+                -- A condition is healthy if its status is True.
+                -- However, for the 'Stopped' condition, a 'False' status is the healthy state.
+                local is_healthy_condition = (condition.status == "True")
+                if condition.type == "Stopped" then
+                  is_healthy_condition = (condition.status == "False")
+                end
+
+                if not is_healthy_condition then
+                  -- This condition represents a problem, so update counters and the message.
+                  if condition.status == "Unknown" then
+                    status_unknown = status_unknown + 1
+                  else
+                    status_false = status_false + 1
+                  end
+
+                  msg = msg .. " | " .. i .. ": " .. condition.type .. " | " .. condition.status
+                  if condition.reason ~= nil and condition.reason ~= "" then
+                    msg = msg .. " | " .. condition.reason
+                  end
+                  if condition.message ~= nil and condition.message ~= "" then
+                    msg = msg .. " | " .. condition.message
+                  end
+                end
+
+              end
+
+              if progressing == false and degraded == false and status_unknown == 0 and status_false == 0 then
+                health_status.status = "Healthy"
+                msg = "InferenceService is healthy."
+              elseif degraded == false and status_unknown >= 0 then
+                health_status.status = "Progressing"
+              else
+                health_status.status = "Degraded"
+              end
+
+              health_status.message = msg
+            end
+          end
+
+          return health_status
+
     resourceExclusions: |
       - apiGroups:
         - tekton.dev


### PR DESCRIPTION
This is needed because in kserve the added a status condition for
stopped, which shouldn't be true when everything is running right, and
without this custom hc, inference services always show up as unhealthy.
