### PR TITLE
Add support for argoProjects and argoProject

### DIFF
--- a/templates/plumbing/applications.yaml
+++ b/templates/plumbing/applications.yaml
@@ -1,5 +1,6 @@
 {{- $namespace := print $.Values.global.pattern "-" $.Values.clusterGroup.name }}
 {{- range .Values.clusterGroup.applications }}
+{{- $projectName := coalesce .argoProject .project "default" -}} {{- /* Read argoProject if set, otherwise .project and otherwise set it to "default" */}}
 {{- if .disabled }} {{- /* This allows us to null out an Application entry by specifying disabled: true in an override file */}}
 {{- else }}
 ---
@@ -22,7 +23,7 @@ spec:
   destination:
     name: {{ $.Values.clusterGroup.targetCluster }}
     namespace: {{ default $namespace .namespace }}
-  project: {{ .project }}
+  project: {{ $projectName }}
   {{- if .chartVersion }} {{- /* if .chartVersion is set we assume this is a multisource app */}}
   sources:
     - repoURL: {{ $.Values.global.repoURL }}

--- a/templates/plumbing/argoProjects.yaml
+++ b/templates/plumbing/argoProjects.yaml
@@ -5,10 +5,22 @@
   described in the values file. This is to support issue 
   https://github.com/validatedpatterns/common/issues/459 created by our customer.
 */ -}}
-{{- if kindIs "map" .Values.clusterGroup.projects }}
-{{- template "clustergroup.template.plumbing.projects.map" (list .Values.clusterGroup.projects $namespace $.Values.enabled) }}  
+{{- /*
+  This template block iterates over the appropriate list based on which value 
+  was provided in the 'values.yaml' file, as enforced by the JSON Schema (oneOf).
+*/ -}}
+{{- $projects := list -}}
+
+{{- if .Values.clusterGroup.projects }}
+  {{- $projects = .Values.clusterGroup.projects -}}
+{{- else if .Values.clusterGroup.argoProjects }}
+  {{- $projects = .Values.clusterGroup.argoProjects -}}
+{{- end }}
+
+{{- if kindIs "map" $projects }}
+{{- template "clustergroup.template.plumbing.projects.map" (list $projects $namespace $.Values.enabled) }}  
 {{- else }}
-{{- range .Values.clusterGroup.projects }}
+{{- range $projects }}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:

--- a/tests/application_projects_test.yaml
+++ b/tests/application_projects_test.yaml
@@ -1,0 +1,75 @@
+suite: Test argo projects inside application 
+templates:
+  - templates/plumbing/applications.yaml
+release:
+  name: release-test
+tests:
+  - it: should output nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an application with a project
+    set:
+      clusterGroup:
+        applications:
+          acm:
+            name: acm
+            namespace: open-cluster-management
+            project: hub
+            chart: acm
+            chartVersion: 0.1.*
+    asserts:
+      - isKind:
+          of: Application
+      - hasDocuments:
+          count: 1
+      - documentSelector:
+          path: metadata.name
+          value: acm
+        equal:
+          path: spec.project
+          value: hub
+
+  - it: should render an application with an argoProject
+    set:
+      clusterGroup:
+        applications:
+          acm:
+            name: acm
+            namespace: open-cluster-management
+            argoProject: hub
+            chart: acm
+            chartVersion: 0.1.*
+    asserts:
+      - isKind:
+          of: Application
+      - hasDocuments:
+          count: 1
+      - documentSelector:
+          path: metadata.name
+          value: acm
+        equal:
+          path: spec.project
+          value: hub
+
+  - it: should render an application without project or argoProject
+    set:
+      clusterGroup:
+        applications:
+          acm:
+            name: acm
+            namespace: open-cluster-management
+            chart: acm
+            chartVersion: 0.1.*
+    asserts:
+      - isKind:
+          of: Application
+      - hasDocuments:
+          count: 1
+      - documentSelector:
+          path: metadata.name
+          value: acm
+        equal:
+          path: spec.project
+          value: default

--- a/tests/argoprojects_test.yaml
+++ b/tests/argoprojects_test.yaml
@@ -1,0 +1,142 @@
+suite: Test projects and argoProjects
+templates:
+  - templates/plumbing/argoProjects.yaml
+release:
+  name: release-test
+tests:
+  - it: should not output projects when with default values (no projects nor argoProjects are set)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not output projects when argoProjects is set to []
+    set:
+      clusterGroup:
+        argoProjects: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not output projects when projects is set to []
+    set:
+      clusterGroup:
+        projects: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not fail when projects and argoProjects are both removed
+    set:
+      clusterGroup:
+        argoProjects: null
+        projects: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when projects and argoProjects are both set to something via lists
+    set:
+      clusterGroup:
+        argoProjects: ["foo", "bar"]
+        projects: ["baz"]
+    asserts:
+      - failedTemplate: {}
+
+  - it: should fail when projects and argoProjects are both set to something via objects
+    set:
+      clusterGroup:
+        argoProjects: 
+          foo:
+          bar:
+        projects:
+          baz:
+    asserts:
+      - failedTemplate: {}
+
+  - it: should render correctly when argoProjects is set to something
+    set:
+      clusterGroup:
+        argoProjects: ["foo", "bar"]
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name  
+          value: foo
+        isSubset:
+          path: spec
+          content:
+            description: "Pattern foo"
+            destinations:
+            - namespace: '*'
+              server: '*'
+            clusterResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            namespaceResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            sourceRepos:
+            - '*'
+      - documentSelector:
+          path: metadata.name  
+          value: bar
+        isSubset:
+          path: spec
+          content:
+            description: "Pattern bar"
+            destinations:
+            - namespace: '*'
+              server: '*'
+            clusterResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            namespaceResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            sourceRepos:
+            - '*'
+
+  - it: should render correctly when projects is set to something
+    set:
+      clusterGroup:
+        projects: ["foo", "bar"]
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name  
+          value: foo
+        isSubset:
+          path: spec
+          content:
+            description: "Pattern foo"
+            destinations:
+            - namespace: '*'
+              server: '*'
+            clusterResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            namespaceResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            sourceRepos:
+            - '*'
+      - documentSelector:
+          path: metadata.name  
+          value: bar
+        isSubset:
+          path: spec
+          content:
+            description: "Pattern bar"
+            destinations:
+            - namespace: '*'
+              server: '*'
+            clusterResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            namespaceResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            sourceRepos:
+            - '*'

--- a/values.schema.json
+++ b/values.schema.json
@@ -369,8 +369,11 @@
             "$ref": "#/definitions/Subscription"
           }
         },
-        "projects": {
+        "argoProjects": {
           "anyOf": [
+            {
+              "type": "null"
+            },
             {
               "type": "array"
             },
@@ -379,6 +382,24 @@
             }
           ],
           "description": "The list of projects that will be created in the ArgoCD instances.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "projects": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "DEPRECATED: The list of projects that will be created in the ArgoCD instances (use argoProjects).",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
@@ -426,9 +447,37 @@
         "applications",
         "isHubCluster",
         "name",
-        "namespaces",
-        "projects"
+        "namespaces"
       ],
+      "not": {
+        "description": "Projects and ArgoProjects cannot both contain non-empty lists at the same time.",
+        "allOf": [
+          { 
+            "required": ["projects"],
+            "properties": { 
+              "projects": {
+                "description": "Non-empty check for projects (array or object)",
+                "anyOf": [
+                  { "type": "array", "minItems": 1 },
+                  { "type": "object", "minProperties": 1 }
+                ]
+              }
+            }
+          },
+          {
+            "required": ["argoProjects"],
+            "properties": { 
+              "projects": {
+                "description": "Non-empty check for argoProjects (array or object)",
+                "anyOf": [
+                  { "type": "array", "minItems": 1 },
+                  { "type": "object", "minProperties": 1 }
+                ]
+              }
+            }
+          }
+        ]
+      },
       "title": "ClusterGroup"
     },
     "Namespaces": {
@@ -569,6 +618,11 @@
         },
         "project": {
           "type": "string",
+          "description": "DEPRECATED. Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project (use argoProject).",
+          "deprecated": true
+        },
+        "argoProject": {
+          "type": "string",
           "description": "Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project."
         },
         "path": {
@@ -581,8 +635,11 @@
         }
       },
       "required": [
-        "name",
-        "project"
+        "name"
+      ],
+      "oneOf": [
+        { "required": [ "project" ] },
+        { "required": [ "argoProject" ] }
       ],
       "title": "Applications"
     },

--- a/values.schema.json
+++ b/values.schema.json
@@ -637,10 +637,13 @@
       "required": [
         "name"
       ],
-      "oneOf": [
-        { "required": [ "project" ] },
-        { "required": [ "argoProject" ] }
-      ],
+      "not": {
+        "description": "Project and argoProject cannot both be set at the same time.",
+        "allOf": [
+          { "required": ["project"] },
+          { "required": ["argoProject"] }
+        ]
+      },
       "title": "Applications"
     },
     "ArgoCD": {

--- a/values.yaml
+++ b/values.yaml
@@ -205,13 +205,14 @@ clusterGroup:
 #     version: '3.12.*'
 #     upgradeConstraintPolicy: SelfCertified
 
-  projects: []
+  # projects is deprecated, please use argoProjects
+  # argoProjects: []
 #  - datacenter
 #
   applications: {}
 #  - name: acm
 #    namespace: default
-#    project: datacenter
+#    argoProject: datacenter
 #    path: applications/acm
 
   extraObjects: {}


### PR DESCRIPTION
Added a bunch of unit tests to cover all cases. Also tested this on an
mcg hub and spoke with the following values files:

* Hub

    argoProjects:
      - hub
      - config-demo
      - hello-world
    applications:
      acm:
        name: acm
        namespace: open-cluster-management
        argoProject: hub
        path: "."
        chartVersion: quick-clustergroup-test
        repoURL: https://github.com/mbaldessari/acm-chart
      vault:
        name: vault
        namespace: vault
        argoProject: hub
        chart: hashicorp-vault
        chartVersion: 0.1.*
      golang-external-secrets:
        name: golang-external-secrets
        namespace: golang-external-secrets
        project: hub
        chart: golang-external-secrets
        chartVersion: 0.1.*
      config-demo:
        name: config-demo
        namespace: config-demo
        project: config-demo
        path: charts/all/config-demo
      hello-world:
        name: hello-world
        namespace: hello-world
        project: hello-world
        path: charts/all/hello-world

* Spoke

No argoProjects nor projects were set on the spoke. We let the default
be picked.

    applications:
      golang-external-secrets:
        name: golang-external-secrets
        namespace: golang-external-secrets
        chart: golang-external-secrets
        chartVersion: 0.1.*
      config-demo:
        name: config-demo
        namespace: config-demo
        path: charts/all/config-demo
      hello-world:
        name: hello-world
        namespace: hello-world
        path: charts/all/hello-world

Closes: https://github.com/validatedpatterns/clustergroup-chart/issues/62
