### PR TITLE
Add vault_jwt tag

### DIFF
--- a/templates/imperative/unsealjob.yaml
+++ b/templates/imperative/unsealjob.yaml
@@ -55,7 +55,7 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init,vault_jwt'
                 - "rhvp.cluster_utils.vault"
               volumeMounts:
                 {{- include "imperative.volumemounts_ca" . | indent 16 }}


### PR DESCRIPTION
It won't do anything anyway as it requires the ansible var
`vault_jwt_config` to be set to true. We want it though because
in the UI we want this stuff to be configured via the cronjob.
