### PR TITLE
Get imperative to work on vault on ocp 4.22

### DIFF
--- a/templates/imperative/vault-exec-role.yaml
+++ b/templates/imperative/vault-exec-role.yaml
@@ -1,0 +1,36 @@
+{{/* Kubernetes 1.35 (OCP 4.22+) requires the 'create' verb on pods/exec for WebSocket-based
+     exec. Grant it to the imperative SA in the vault namespace so k8s_exec can reach vault-0. */}}
+{{- if or (eq .Values.global.secretStore.backend "vault") (not (hasKey .Values.global.secretStore "backend")) }}
+{{- if not (eq .Values.enabled "plumbing") }}
+{{- if $.Values.clusterGroup.imperative.serviceAccountCreate }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-pod-exec
+  namespace: {{ $.Values.clusterGroup.imperative.vaultNamespace }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods/exec
+    verbs:
+    - create
+    - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.namespace }}-vault-exec-rolebinding
+  namespace: {{ $.Values.clusterGroup.imperative.vaultNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-pod-exec
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+    namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/tests/imperative_vault_exec_role_test.yaml
+++ b/tests/imperative_vault_exec_role_test.yaml
@@ -1,0 +1,148 @@
+suite: Test vault pods/exec Role and RoleBinding for OCP
+templates:
+  - templates/imperative/vault-exec-role.yaml
+release:
+  name: release-test
+tests:
+  - it: should create vault exec role by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should create vault exec role and rolebinding
+    set:
+      global:
+        secretStore:
+          backend: vault
+      clusterGroup:
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: vault-pod-exec
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: vault
+      - documentIndex: 0
+        equal:
+          path: rules[0].apiGroups[0]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: rules[0].resources[0]
+          value: pods/exec
+      - documentIndex: 0
+        contains:
+          path: rules[0].verbs
+          content: create
+      - documentIndex: 0
+        contains:
+          path: rules[0].verbs
+          content: get
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: imperative-vault-exec-rolebinding
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: vault
+      - documentIndex: 1
+        equal:
+          path: roleRef.name
+          value: vault-pod-exec
+      - documentIndex: 1
+        equal:
+          path: subjects[0].name
+          value: imperative-sa
+      - documentIndex: 1
+        equal:
+          path: subjects[0].namespace
+          value: imperative
+
+  - it: should not create vault exec role when backend is not vault
+    set:
+      global:
+        secretStore:
+          backend: none
+      clusterGroup:
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create vault exec role when backend key is missing (defaults to vault)
+    set:
+      global:
+        secretStore: {}
+      clusterGroup:
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+
+  - it: should not create vault exec role when serviceAccountCreate is false
+    set:
+      global:
+        secretStore:
+          backend: vault
+      clusterGroup:
+        imperative:
+          serviceAccountCreate: false
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom vaultNamespace
+    set:
+      global:
+        secretStore:
+          backend: vault
+      clusterGroup:
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: custom-vault
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: custom-vault
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: custom-vault

--- a/values.schema.json
+++ b/values.schema.json
@@ -916,6 +916,11 @@
         },
         "adminClusterRoleName": {
           "type": "string"
+        },
+        "vaultNamespace": {
+          "type": "string",
+          "description": "Namespace where the Vault pod runs. Used to grant pods/exec RBAC on OCP 4.22+ (Kubernetes 1.35+).",
+          "default": "vault"
         }
       },
       "required": [

--- a/values.yaml
+++ b/values.yaml
@@ -115,6 +115,8 @@ clusterGroup:
     adminServiceAccountCreate: true
     adminServiceAccountName: imperative-admin-sa
     adminClusterRoleName: imperative-admin-cluster-role
+    # -- Namespace where the Vault pod runs. Used to grant pods/exec RBAC on OCP 4.22+ (Kubernetes 1.35+).
+    vaultNamespace: "vault"
 
   managedClusterGroups: {}
   namespaces: []


### PR DESCRIPTION
In Kubernetes 1.35 (which OCP 4.22 is based on), a new security feature
was introduced: synthetic RBAC CREATE authorization checks for WebSocket
upgrade requests (like pods/exec, pods/attach, pods/portforward).

Previously, exec went over SPDY and only required get/connect
permissions — your wildcard get/list/watch ClusterRole worked fine.
Starting in 1.35, the API server enforces an additional create verb
check on pods/exec whenever a WebSocket upgrade happens. This is to
close a privilege escalation path where read-only users could exec into
pods via the GET-to-WebSocket upgrade.

This way we conditionally allow the imperative namespace to exec into the
vault namespace.

Tested on 4.22 and 4.21
