### PR TITLE
Fix spokes non-existing vault namespace error

### DIFF
--- a/templates/imperative/vault-exec-role.yaml
+++ b/templates/imperative/vault-exec-role.yaml
@@ -3,6 +3,16 @@
 {{- if or (eq .Values.global.secretStore.backend "vault") (not (hasKey .Values.global.secretStore "backend")) }}
 {{- if not (eq .Values.enabled "plumbing") }}
 {{- if $.Values.clusterGroup.imperative.serviceAccountCreate }}
+{{- $hashicorp_vault_found := false }}
+{{- range .Values.clusterGroup.applications }}
+  {{- if . }} {{- /* Skip null applications */}}
+    {{- if eq .chart "hashicorp-vault" }}
+      {{- $hashicorp_vault_found = true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if or (eq (include "clustergroup.ishubcluster" .) "true") $hashicorp_vault_found }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -31,6 +41,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
     namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/tests/imperative_vault_exec_role_test.yaml
+++ b/tests/imperative_vault_exec_role_test.yaml
@@ -4,7 +4,10 @@ templates:
 release:
   name: release-test
 tests:
-  - it: should create vault exec role by default
+  - it: should create vault exec role by default on hub cluster
+    set:
+      clusterGroup:
+        isHubCluster: true
     asserts:
       - hasDocuments:
           count: 2
@@ -15,6 +18,7 @@ tests:
         secretStore:
           backend: vault
       clusterGroup:
+        isHubCluster: true
         imperative:
           serviceAccountCreate: true
           serviceAccountName: imperative-sa
@@ -94,6 +98,7 @@ tests:
       global:
         secretStore: {}
       clusterGroup:
+        isHubCluster: true
         imperative:
           serviceAccountCreate: true
           serviceAccountName: imperative-sa
@@ -130,6 +135,7 @@ tests:
         secretStore:
           backend: vault
       clusterGroup:
+        isHubCluster: true
         imperative:
           serviceAccountCreate: true
           serviceAccountName: imperative-sa
@@ -146,3 +152,53 @@ tests:
         equal:
           path: metadata.namespace
           value: custom-vault
+
+  - it: should not create vault exec role on spoke cluster without hashicorp-vault app
+    set:
+      global:
+        secretStore:
+          backend: vault
+      clusterGroup:
+        isHubCluster: false
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+        applications:
+          test:
+            name: test
+            namespace: test
+            project: test
+            chart: test-chart
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create vault exec role on spoke cluster with hashicorp-vault app
+    set:
+      global:
+        secretStore:
+          backend: vault
+      clusterGroup:
+        isHubCluster: false
+        imperative:
+          serviceAccountCreate: true
+          serviceAccountName: imperative-sa
+          namespace: imperative
+          vaultNamespace: vault
+        applications:
+          vault:
+            name: vault
+            namespace: vault
+            project: hub
+            chart: hashicorp-vault
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding


### PR DESCRIPTION
In the commit where we added support for rbacs for OCP 4.22 in the imperative
bits we did not make it conditional on running on the hub.

Let's do that, since there is no vault on the spoke by default
