### PR TITLE
Add .main.variant support

### DIFF
--- a/values.schema.json
+++ b/values.schema.json
@@ -62,14 +62,20 @@
     "Main": {
       "type": "object",
       "additionalProperties": true,
-      "required": [
-        "clusterGroupName"
+      "oneOf": [
+        { "required": ["clusterGroupName"] },
+        { "required": ["variant"] }
       ],
       "title": "Main",
       "description": "This section contains the 'main' variables which are used by the install chart only and are passed to helm via the Makefile",
       "properties": {
         "clusterGroupName": {
-          "type": "string"
+          "type": "string",
+          "description": "This identifies which variant of the pattern to use (same thing as variant)"
+        },
+        "variant": {
+          "type": "string",
+          "description": "This identifies which variant of the pattern to use (same thing as clusterGroupName)"
         },
         "multiSourceRepoUrl": {
           "type": "string",


### PR DESCRIPTION
.main.clusterGroupName today defines the flavour/variant of a pattern.
This is confusing for users as it is not particularly intuitive.

Let's add .main.variant which will mean the exact same thing while being
more explicit.

The reason for this is to migrate patterns to the new value to make
the intent clearer.
