### PR TITLE
New value folder structure support

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,6 +40,8 @@ Default always defined top-level variables for helm charts
   value: {{ $.Values.global.gitOpsSubNamespace | default "" }}
 - name: global.vpArgoNamespace
   value: {{ $.Values.global.vpArgoNamespace }}
+- name: global.vpNewFolderDir
+  value: {{ $.Values.global.vpNewFolderDir | default "false" | quote }}
 {{- end }} {{/* clustergroup.globalvaluesparameters */}}
 
 
@@ -47,6 +49,23 @@ Default always defined top-level variables for helm charts
 Default always defined valueFiles to be included in Applications
 */}}
 {{- define "clustergroup.app.globalvalues.valuefiles" -}}
+{{- if $.Values.global.vpNewFolderDir }}
+- "/values-global.yaml"
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.clusterGroup.name }}.yaml"
+{{- if $.Values.global.clusterPlatform }}
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}.yaml"
+  {{- if $.Values.global.clusterVersion }}
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml"
+  {{- end }}
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.clusterVersion }}
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.localClusterName }}
+- "/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.localClusterName }}.yaml"
+{{- end }}
+{{- else }}
 - "/values-global.yaml"
 - "/values-{{ $.Values.clusterGroup.name }}.yaml"
 {{- if $.Values.global.clusterPlatform }}
@@ -62,6 +81,7 @@ Default always defined valueFiles to be included in Applications
 {{- if $.Values.global.localClusterName }}
 - "/values-{{ $.Values.global.localClusterName }}.yaml"
 {{- end }}
+{{- end }} {{/* if $.Values.global.vpNewFolderDir */}}
 {{- if $.Values.global.extraValueFiles }}
 {{- range $.Values.global.extraValueFiles }}
 - {{ . | quote }}
@@ -99,6 +119,23 @@ Default always defined valueFiles to be included in Applications
 Default always defined valueFiles to be included in Applications but with a prefix called $patternref
 */}}
 {{- define "clustergroup.app.globalvalues.prefixedvaluefiles" -}}
+{{- if $.Values.global.vpNewFolderDir }}
+- "$patternref/values-global.yaml"
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.clusterGroup.name }}.yaml"
+{{- if $.Values.global.clusterPlatform }}
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}.yaml"
+  {{- if $.Values.global.clusterVersion }}
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml"
+  {{- end }}
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.clusterVersion }}
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.localClusterName }}
+- "$patternref/variants/{{ $.Values.clusterGroup.name }}/values-{{ $.Values.global.localClusterName }}.yaml"
+{{- end }}
+{{- else }}
 - "$patternref/values-global.yaml"
 - "$patternref/values-{{ $.Values.clusterGroup.name }}.yaml"
 {{- if $.Values.global.clusterPlatform }}
@@ -114,6 +151,7 @@ Default always defined valueFiles to be included in Applications but with a pref
 {{- if $.Values.global.localClusterName }}
 - "$patternref/values-{{ $.Values.global.localClusterName }}.yaml"
 {{- end }}
+{{- end }} {{/* if $.Values.global.vpNewFolderDir */}}
 {{- if $.Values.global.extraValueFiles }}
 {{- range $.Values.global.extraValueFiles }}
 - "$patternref/{{ . }}"

--- a/tests/application_multi_source_test.yaml
+++ b/tests/application_multi_source_test.yaml
@@ -62,7 +62,7 @@ tests:
           value: acm
         lengthEqual:
           path: spec.sources[1].helm.parameters
-          count: 19
+          count: 20
       - documentSelector:
           path: metadata.name
           value: vault
@@ -96,4 +96,4 @@ tests:
           value: acm
         lengthEqual:
           path: spec.sources[1].helm.parameters
-          count: 21
+          count: 22

--- a/tests/application_values_folder_dir_test.yaml
+++ b/tests/application_values_folder_dir_test.yaml
@@ -1,0 +1,211 @@
+suite: Test vpNewFolderDir valueFiles layout
+templates:
+  - templates/plumbing/applications.yaml
+release:
+  name: release-test
+tests:
+  - it: should use flat value file paths when vpNewFolderDir is not set
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        targetRevision: main
+        pattern: test-pattern
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            path: charts/test-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source.helm.valueFiles
+          value:
+            - "/values-global.yaml"
+            - "/values-hub.yaml"
+
+  - it: should use variants directory paths when vpNewFolderDir is true
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        targetRevision: main
+        pattern: test-pattern
+        vpNewFolderDir: true
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            path: charts/test-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source.helm.valueFiles
+          value:
+            - "/values-global.yaml"
+            - "/variants/hub/values-hub.yaml"
+
+  - it: should use variants directory paths with platform and version when vpNewFolderDir is true
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        targetRevision: main
+        pattern: test-pattern
+        vpNewFolderDir: true
+        clusterPlatform: AWS
+        clusterVersion: "4.16"
+        localClusterName: mycluster
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            path: charts/test-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source.helm.valueFiles
+          value:
+            - "/values-global.yaml"
+            - "/variants/hub/values-hub.yaml"
+            - "/variants/hub/values-AWS.yaml"
+            - "/variants/hub/values-AWS-4.16.yaml"
+            - "/variants/hub/values-AWS-hub.yaml"
+            - "/variants/hub/values-4.16-hub.yaml"
+            - "/variants/hub/values-mycluster.yaml"
+
+  - it: should use flat value file paths with platform and version when vpNewFolderDir is not set
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        targetRevision: main
+        pattern: test-pattern
+        clusterPlatform: AWS
+        clusterVersion: "4.16"
+        localClusterName: mycluster
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            path: charts/test-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source.helm.valueFiles
+          value:
+            - "/values-global.yaml"
+            - "/values-hub.yaml"
+            - "/values-AWS.yaml"
+            - "/values-AWS-4.16.yaml"
+            - "/values-AWS-hub.yaml"
+            - "/values-4.16-hub.yaml"
+            - "/values-mycluster.yaml"
+
+  - it: should use prefixed variants directory paths for multi-source when vpNewFolderDir is true
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        multiSourceRepoUrl: https://charts.validatedpatterns.io
+        targetRevision: main
+        pattern: test-pattern
+        vpNewFolderDir: true
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            chart: test-chart
+            chartVersion: 0.1.*
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.sources[1].helm.valueFiles
+          value:
+            - "$patternref/values-global.yaml"
+            - "$patternref/variants/hub/values-hub.yaml"
+
+  - it: should use flat prefixed paths for multi-source when vpNewFolderDir is not set
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        multiSourceRepoUrl: https://charts.validatedpatterns.io
+        targetRevision: main
+        pattern: test-pattern
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            chart: test-chart
+            chartVersion: 0.1.*
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.sources[1].helm.valueFiles
+          value:
+            - "$patternref/values-global.yaml"
+            - "$patternref/values-hub.yaml"
+
+  - it: should use prefixed variants directory paths with platform for multi-source when vpNewFolderDir is true
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        multiSourceRepoUrl: https://charts.validatedpatterns.io
+        targetRevision: main
+        pattern: test-pattern
+        vpNewFolderDir: true
+        clusterPlatform: AWS
+        clusterVersion: "4.16"
+        localClusterName: mycluster
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            chart: test-chart
+            chartVersion: 0.1.*
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.sources[1].helm.valueFiles
+          value:
+            - "$patternref/values-global.yaml"
+            - "$patternref/variants/hub/values-hub.yaml"
+            - "$patternref/variants/hub/values-AWS.yaml"
+            - "$patternref/variants/hub/values-AWS-4.16.yaml"
+            - "$patternref/variants/hub/values-AWS-hub.yaml"
+            - "$patternref/variants/hub/values-4.16-hub.yaml"
+            - "$patternref/variants/hub/values-mycluster.yaml"
+
+  - it: should preserve extraValueFiles alongside variants directory paths when vpNewFolderDir is true
+    set:
+      global:
+        repoURL: https://github.com/validatedpatterns/test-pattern
+        targetRevision: main
+        pattern: test-pattern
+        vpNewFolderDir: true
+        extraValueFiles:
+          - "/extra/custom-values.yaml"
+      clusterGroup:
+        name: hub
+        applications:
+          - name: test-app
+            namespace: test-namespace
+            path: charts/test-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source.helm.valueFiles
+          value:
+            - "/values-global.yaml"
+            - "/variants/hub/values-hub.yaml"
+            - "/extra/custom-values.yaml"

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,8 @@ global:
   pattern: common
   # cluster-wide argo namespace
   vpArgoNamespace: openshift-gitops
+  # Are values files under ./variants/<variant>/values-*.yaml
+  vpNewFolderDir: false
   secretLoader:
     disabled: false
   secretStore:


### PR DESCRIPTION
When the operator detects a top-level "variants" folder, we use the
values like:

  /values-global.yaml
  /variants/<variant>/values-<variant>.yaml
  ....

the operator also sets global.vpNewFolderDir to true, so whenever we detect
this value we also switch to the new values files folder structure
