### PR TITLE
Add global.catalogSource fallback for OLM subscriptions

### DIFF
--- a/templates/core/subscriptions.yaml
+++ b/templates/core/subscriptions.yaml
@@ -14,8 +14,8 @@ metadata:
   {{- include "clustergroup.annotations" $subs.annotations | nindent 2 }}
 spec:
   name: {{ $subs.name }}
-  source: {{ default "redhat-operators" $subs.source }}
-  sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
+  source: {{ default (default "redhat-operators" $.Values.global.catalogSource) $subs.source }}
+  sourceNamespace: {{ default (default "openshift-marketplace" $.Values.global.catalogSourceNamespace) $subs.sourceNamespace }}
   {{- if $subs.channel }}
   channel: {{ $subs.channel }}
   {{- end }} {{/* if $subs.channel */}}
@@ -65,8 +65,8 @@ metadata:
   {{- include "clustergroup.annotations" $subs.annotations | nindent 2 }}
 spec:
   name: {{ $subs.name }}
-  source: {{ default "redhat-operators" $subs.source }}
-  sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
+  source: {{ default (default "redhat-operators" $.Values.global.catalogSource) $subs.source }}
+  sourceNamespace: {{ default (default "openshift-marketplace" $.Values.global.catalogSourceNamespace) $subs.sourceNamespace }}
   {{- if $subs.channel }}
   channel: {{ $subs.channel }}
   {{- end }}

--- a/tests/subscriptions_test.yaml
+++ b/tests/subscriptions_test.yaml
@@ -102,6 +102,111 @@ tests:
           path: spec.config.env[0].value
           value: bar
         
+  - it: should use global.catalogSource as fallback when no per-subscription source is set
+    set:
+      global:
+        catalogSource: my-custom-catalog
+        catalogSourceNamespace: my-custom-namespace
+      clusterGroup:
+        subscriptions:
+          acm:
+            name: advanced-cluster-management
+            namespace: open-cluster-management
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source
+          value: my-custom-catalog
+      - equal:
+          path: spec.sourceNamespace
+          value: my-custom-namespace
+
+  - it: should let per-subscription source override global.catalogSource
+    set:
+      global:
+        catalogSource: my-custom-catalog
+        catalogSourceNamespace: my-custom-namespace
+      clusterGroup:
+        subscriptions:
+          acm:
+            name: advanced-cluster-management
+            namespace: open-cluster-management
+            source: per-sub-catalog
+            sourceNamespace: per-sub-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source
+          value: per-sub-catalog
+      - equal:
+          path: spec.sourceNamespace
+          value: per-sub-namespace
+
+  - it: should use global.catalogSource as fallback for namespaced subscriptions
+    set:
+      global:
+        catalogSource: my-custom-catalog
+        catalogSourceNamespace: my-custom-namespace
+      clusterGroup:
+        subscriptions:
+          acm:
+            name: advanced-cluster-management
+            namespaces:
+            - ns-one
+            - ns-two
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.namespace
+          value: ns-one
+        equal:
+          path: spec.source
+          value: my-custom-catalog
+      - documentSelector:
+          path: metadata.namespace
+          value: ns-one
+        equal:
+          path: spec.sourceNamespace
+          value: my-custom-namespace
+      - documentSelector:
+          path: metadata.namespace
+          value: ns-two
+        equal:
+          path: spec.source
+          value: my-custom-catalog
+      - documentSelector:
+          path: metadata.namespace
+          value: ns-two
+        equal:
+          path: spec.sourceNamespace
+          value: my-custom-namespace
+
+  - it: should let per-subscription source override global.catalogSource for namespaced subscriptions
+    set:
+      global:
+        catalogSource: my-custom-catalog
+        catalogSourceNamespace: my-custom-namespace
+      clusterGroup:
+        subscriptions:
+          acm:
+            name: advanced-cluster-management
+            namespaces:
+            - ns-one
+            source: per-sub-catalog
+            sourceNamespace: per-sub-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.source
+          value: per-sub-catalog
+      - equal:
+          path: spec.sourceNamespace
+          value: per-sub-namespace
+
   - it: should output one subscription per namespace
     set:
       clusterGroup:

--- a/values.schema.json
+++ b/values.schema.json
@@ -200,6 +200,14 @@
         "options": {
           "$ref": "#/definitions/Options"
         },
+        "catalogSource": {
+          "type": "string",
+          "description": "Default catalog source for all OLM subscriptions. Individual subscriptions can override via their own source field."
+        },
+        "catalogSourceNamespace": {
+          "type": "string",
+          "description": "Default catalog source namespace for all OLM subscriptions. Individual subscriptions can override via their own sourceNamespace field."
+        },
         "secretStore": {
           "$ref": "#/definitions/GlobalSecretStore"
         },


### PR DESCRIPTION
## Problem

Currently, the clustergroup chart hardcodes the OLM subscription source fallback per-entry with no global hook:

```yaml
source: {{ default "redhat-operators" $subs.source }}
sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
```

This means every disconnected/airgap consumer must override `source:` on every single subscription. For patterns with 8+ operators, this creates significant repetition and increases the risk of missing an operator during mirror setup.

## Solution

Add `global.catalogSource` and `global.catalogSourceNamespace` fields that act as a middle layer in the fallback chain, following the precedent already established by `global.options.installPlanApproval` and `global.options.useCSV`.

**Fallback order (highest to lowest precedence):**
1. Per-subscription `source` (allows specific operators to use different catalogs)
2. `global.catalogSource` (new - allows one-value airgap repoint)
3. Hardcoded default `"redhat-operators"` (unchanged)

## Changes

**templates/core/subscriptions.yaml:**
```yaml
source: {{ default (default "redhat-operators" $.Values.global.catalogSource) $subs.source }}
sourceNamespace: {{ default (default "openshift-marketplace" $.Values.global.catalogSourceNamespace) $subs.sourceNamespace }}
```

**values.schema.json** - Add under `Global` definition:
```json
"catalogSource": {
  "type": "string",
  "description": "Default catalog source for all OLM subscriptions. Individual subscriptions can override via their own source field."
},
"catalogSourceNamespace": {
  "type": "string", 
  "description": "Default catalog source namespace for all OLM subscriptions. Individual subscriptions can override via their own sourceNamespace field."
}
```

## Backward Compatibility

✅ **Fully backward compatible** - existing patterns are unaffected:
- When `global.catalogSource` is unset, behavior is identical to today
- Per-subscription `source` still takes precedence (certified operators can use different catalogs)
- Default remains `"redhat-operators"` when neither global nor per-sub values are set

## Use Case

Airgap/disconnected deployments where all operators come from a single mirrored catalog:

```yaml
# Before (values-baremetal.yaml) - must override every subscription
clusterGroup:
  subscriptions:
    acm:
      source: cs-redhat-operator-index-v4-21
      sourceNamespace: openshift-marketplace
    eso:
      source: cs-redhat-operator-index-v4-21
      sourceNamespace: openshift-marketplace
    # ... repeat for 8+ operators

# After - one global default
global:
  catalogSource: cs-redhat-operator-index-v4-21
  catalogSourceNamespace: openshift-marketplace

# Individual overrides still work when needed
clusterGroup:
  subscriptions:
    gpu-operator:
      source: cs-certified-operator-index-v4-21  # Uses certified catalog
```

## Precedent

This follows the existing pattern used by `global.options.installPlanApproval` and `global.options.useCSV`, which already provide global defaults for subscription fields.

## Testing Checklist

- [ ] Verify existing patterns work unchanged (global.catalogSource unset)
- [ ] Verify global.catalogSource applies to all subscriptions
- [ ] Verify per-subscription source override still takes precedence